### PR TITLE
Update mathjax-loader to a supported cdn

### DIFF
--- a/mathjax-loader.js
+++ b/mathjax-loader.js
@@ -6,7 +6,7 @@
         state = states.start,
         queue = [],
         mathjaxHub,
-        src = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js',
+        src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js',
         element_prototype = Object.create(HTMLElement.prototype);
 
     function flush_queue() {


### PR DESCRIPTION
Mathjax has discontinued supporting their CDN at cdn.mathjax.org. This uses one of the recommended replacements at https://www.mathjax.org/cdn-shutting-down/.

There doesn't appear to be a latest option at this new CDN.